### PR TITLE
Remove `copyStorage`, `mockFunction` supported in `forge-std`

### DIFF
--- a/src/IKontrolCheatsBase.sol
+++ b/src/IKontrolCheatsBase.sol
@@ -19,10 +19,6 @@ interface KontrolCheatsBase {
     function expectCreate2(address,uint256,bytes calldata) external;
     // Makes the storage of the given address completely symbolic.
     function symbolicStorage(address) external;
-    // Copies the storage of one account into another
-    function copyStorage(address,address) external;
-    // From now on, whenever a call is made to callee with calldata data, instead call calledContract with the same calldata.
-    function mockFunction(address callee, address calledContract, bytes calldata data) external;
     // Adds an address to the whitelist.
     function allowCallsToAddress(address) external;
     // Adds an address and a storage slot to the whitelist.


### PR DESCRIPTION
This PR removes `copyStorage`, `mockFunction` functions from `KontrolCheatsBase`, since they're now part of `forge-std`: https://github.com/foundry-rs/forge-std/pull/602.

Once this PR is merged, I'll open a follow-up one in Kontrol that bumps Foundry, `kontrol-cheatcodes` versions in end-to-end tests and changes `kevm.copyStorage` to `vm.copyStorage` in tests, etc.