### PR TITLE
Fix Soldeer Publish and Release workflow 

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -13,6 +13,9 @@ jobs:
       - name: 'Install expect'
         run: sudo apt-get update && sudo apt-get install -y expect
       
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1.2.0
+
       - name: 'Run Expect Script'
         run: expect scripts/soldeer_publish.sh ${{ vars.SOLDEER_EMAIL }} ${{ secrets.SOLDEER_PASSWORD }}
 

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -29,11 +29,3 @@ jobs:
           set -x
           short_sha=$(git rev-parse --short ${{ github.sha }})
           gh release create ${short_sha} --target ${{ github.sha }}
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: 'Build'
-        run: cargo install soldeer
-
-      - name: 'Run tests'


### PR DESCRIPTION
Drop manual cargo install and use the 'expect script' to handle every thing else.