### PR TITLE
Updating Soldeer Release with a Version to a specific project

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 'Run Expect Script'
         shell: bash
         run: |
-          script -q -c "expect scripts/soldeer_publish.expect ${{ vars.SOLDEER_EMAIL }} ${{ secrets.SOLDEER_PASSWORD }}" /dev/null
+          script -q -c "expect scripts/soldeer_publish.expect ${{ vars.SOLDEER_EMAIL }} ${{ secrets.SOLDEER_PASSWORD }} ${{ github.event.push.head.sha }}" /dev/null
 
       - name: 'Check out code'
         uses: actions/checkout@v3

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -22,13 +22,9 @@ jobs:
       - name: 'Run Expect Script'
         shell: bash
         run: |
+          pushd src > /dev/null
           script -q -c "expect scripts/soldeer_publish.expect ${{ vars.SOLDEER_EMAIL }} ${{ secrets.SOLDEER_PASSWORD }} ${{ github.event.push.head.sha }}" /dev/null
-
-      - name: 'Check out code'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.push.head.sha }}
-          fetch-depth: 0
+          popd > /dev/null
 
       - name: 'Create release'
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Dry-run artifacts
+*.zip

--- a/scripts/soldeer_publish.expect
+++ b/scripts/soldeer_publish.expect
@@ -48,7 +48,7 @@ expect {
 expect eof
 
 # Command to push after login
-set push_command "forge soldeer push"
+set push_command "forge soldeer push kontrol-cheatcodes~[lindex $argv 2]"
 
 # Start the push process
 spawn bash -c "$push_command"


### PR DESCRIPTION
- Add additional argument to set the version of the pushed soldeer account
new file:   .gitignore
- Ignore the zip archive produced by soldeer push dry-run mode
modified:   scripts/soldeer_publish.expect
- Update expect script to use an additional argument for setting the
  pushed version of the cheatcodes to soldeer