### PR TITLE
Make `freshBool` return `bool` instead of `uint256`

### DIFF
--- a/src/IKontrolCheatsBase.sol
+++ b/src/IKontrolCheatsBase.sol
@@ -30,7 +30,7 @@ interface KontrolCheatsBase {
     // Returns a symbolic unsigned integer
     function freshUInt(uint8) external view returns (uint256);
     // Returns a symbolic boolean value
-    function freshBool() external view returns (uint256);
+    function freshBool() external view returns (bool);
     // Returns a symbolic byte array
     function freshBytes(uint256) external view returns (bytes memory);
     // Returns a symbolic address


### PR DESCRIPTION
As pointed out by @lucasmt, the cheatcode `freshBool` is returning `uint256` instead of `bool`. This implies that its usage can be an awkward `kevm.freshBool() != 0` instead of just `kevm.freshBool()`.

As per the [`cheatcodes.md` file](https://github.com/runtimeverification/kontrol/blob/master/src/kontrol/kdist/cheatcodes.md#freshbool---returns-a-single-symbolic-boolean), it should return a `bool` as well.