### PR TITLE
Add fresh* cheatcodes with string args

### DIFF
--- a/src/IKontrolCheatsBase.sol
+++ b/src/IKontrolCheatsBase.sol
@@ -19,6 +19,10 @@ interface KontrolCheatsBase {
     function expectCreate2(address,uint256,bytes calldata) external;
     // Makes the storage of the given address completely symbolic.
     function symbolicStorage(address) external;
+    // Makes the storage of the given address completely symbolic with specified K variable name.
+    function symbolicStorage(address, string calldata) external;
+    // Makes the storage of the given address completely symbolic with specified K variable name.
+    function setArbitraryStorage(address, string calldata) external;
     // Adds an address to the whitelist.
     function allowCallsToAddress(address) external;
     // Adds an address and a storage slot to the whitelist.
@@ -29,10 +33,18 @@ interface KontrolCheatsBase {
     function setGas(uint256) external;
     // Returns a symbolic unsigned integer
     function freshUInt(uint8) external view returns (uint256);
+    // Returns a symbolic unsigned integer with specified K variable name.
+    function freshUInt(uint8, string calldata) external returns (uint256);
     // Returns a symbolic boolean value
     function freshBool() external view returns (bool);
+    // Returns a symbolic boolean value with specified K variable name.
+    function freshBool(string calldata) external returns (bool);
     // Returns a symbolic byte array
     function freshBytes(uint256) external view returns (bytes memory);
+    // Returns a symbolic byte array with specified K variable name.
+    function freshBytes(uint256, string calldata) external returns (bytes memory);
     // Returns a symbolic address
     function freshAddress() external view returns (address);
+    // Returns a symbolic address with specified K variable name.
+    function freshAddress(string calldata) external returns (address);
 }

--- a/src/KontrolCheats.sol
+++ b/src/KontrolCheats.sol
@@ -272,4 +272,263 @@ abstract contract KontrolCheats {
     function freshSInt8() internal view returns (int8) {
         return int8(uint8((kevm.freshUInt(1))));
     }
+    function freshUInt256(string memory var_name) internal returns (uint256) {
+        return kevm.freshUInt(32, var_name);
+    }
+
+    function freshUInt248(string memory var_name) internal returns (uint248) {
+        return uint248(kevm.freshUInt(31, var_name));
+    }
+
+    function freshUInt240(string memory var_name) internal returns (uint240) {
+        return uint240(kevm.freshUInt(30, var_name));
+    }
+
+    function freshUInt232(string memory var_name) internal returns (uint232) {
+        return uint232(kevm.freshUInt(29, var_name));
+    }
+
+    function freshUInt224(string memory var_name) internal returns (uint224) {
+        return uint224(kevm.freshUInt(28, var_name));
+    }
+
+    function freshUInt216(string memory var_name) internal returns (uint216) {
+        return uint216(kevm.freshUInt(27, var_name));
+    }
+
+    function freshUInt208(string memory var_name) internal returns (uint208) {
+        return uint208(kevm.freshUInt(26, var_name));
+    }
+
+    function freshUInt200(string memory var_name) internal returns (uint200) {
+        return uint200(kevm.freshUInt(25, var_name));
+    }
+
+    function freshUInt192(string memory var_name) internal returns (uint192) {
+        return uint192(kevm.freshUInt(24, var_name));
+    }
+
+    function freshUInt184(string memory var_name) internal returns (uint184) {
+        return uint184(kevm.freshUInt(23, var_name));
+    }
+
+    function freshUInt176(string memory var_name) internal returns (uint176) {
+        return uint176(kevm.freshUInt(22, var_name));
+    }
+
+    function freshUInt168(string memory var_name) internal returns (uint168) {
+        return uint168(kevm.freshUInt(21, var_name));
+    }
+
+    function freshUInt160(string memory var_name) internal returns (uint160) {
+        return uint160(kevm.freshUInt(20, var_name));
+    }
+
+    function freshUInt152(string memory var_name) internal returns (uint152) {
+        return uint152(kevm.freshUInt(19, var_name));
+    }
+
+    function freshUInt144(string memory var_name) internal returns (uint144) {
+        return uint144(kevm.freshUInt(18, var_name));
+    }
+
+    function freshUInt136(string memory var_name) internal returns (uint136) {
+        return uint136(kevm.freshUInt(17, var_name));
+    }
+
+    function freshUInt128(string memory var_name) internal returns (uint128) {
+        return uint128(kevm.freshUInt(16, var_name));
+    }
+
+    function freshUInt120(string memory var_name) internal returns (uint120) {
+        return uint120(kevm.freshUInt(15, var_name));
+    }
+
+    function freshUInt112(string memory var_name) internal returns (uint112) {
+        return uint112(kevm.freshUInt(14, var_name));
+    }
+
+    function freshUInt104(string memory var_name) internal returns (uint104) {
+        return uint104(kevm.freshUInt(13, var_name));
+    }
+
+    function freshUInt96(string memory var_name) internal returns (uint96) {
+        return uint96(kevm.freshUInt(12, var_name));
+    }
+
+    function freshUInt88(string memory var_name) internal returns (uint88) {
+        return uint88(kevm.freshUInt(11, var_name));
+    }
+
+    function freshUInt80(string memory var_name) internal returns (uint80) {
+        return uint80(kevm.freshUInt(10, var_name));
+    }
+
+    function freshUInt72(string memory var_name) internal returns (uint72) {
+        return uint72(kevm.freshUInt(9, var_name));
+    }
+
+    function freshUInt64(string memory var_name) internal returns (uint64) {
+        return uint64(kevm.freshUInt(8, var_name));
+    }
+
+    function freshUInt56(string memory var_name) internal returns (uint56) {
+        return uint56(kevm.freshUInt(7, var_name));
+    }
+
+    function freshUInt48(string memory var_name) internal returns (uint48) {
+        return uint48(kevm.freshUInt(6, var_name));
+    }
+
+    function freshUInt40(string memory var_name) internal returns (uint40) {
+        return uint40(kevm.freshUInt(5, var_name));
+    }
+
+    function freshUInt32(string memory var_name) internal returns (uint32) {
+        return uint32(kevm.freshUInt(4, var_name));
+    }
+
+    function freshUInt24(string memory var_name) internal returns (uint24) {
+        return uint24(kevm.freshUInt(3, var_name));
+    }
+
+    function freshUInt16(string memory var_name) internal returns (uint16) {
+        return uint16(kevm.freshUInt(2, var_name));
+    }
+
+    function freshUInt8(string memory var_name) internal returns (uint8) {
+        return uint8(kevm.freshUInt(1, var_name));
+    }
+
+    function freshAddress(string memory var_name) internal returns (address) {
+        return address(uint160(kevm.freshUInt(20, var_name)));
+    }
+
+    function freshSInt256(string memory var_name) internal returns (int256) {
+        return int256(kevm.freshUInt(32, var_name));
+    }
+
+    function freshSInt248(string memory var_name) internal returns (int248) {
+        return int248(uint248(kevm.freshUInt(31, var_name)));
+    }
+
+    function freshSInt240(string memory var_name) internal returns (int240) {
+        return int240(uint240(kevm.freshUInt(30, var_name)));
+    }
+
+    function freshSInt232(string memory var_name) internal returns (int232) {
+        return int232(uint232(kevm.freshUInt(29, var_name)));
+    }
+
+    function freshSInt224(string memory var_name) internal returns (int224) {
+        return int224(uint224(kevm.freshUInt(28, var_name)));
+    }
+
+    function freshSInt216(string memory var_name) internal returns (int216) {
+        return int216(uint216(kevm.freshUInt(27, var_name)));
+    }
+
+    function freshSInt208(string memory var_name) internal returns (int208) {
+        return int208(uint208(kevm.freshUInt(26, var_name)));
+    }
+
+    function freshSInt200(string memory var_name) internal returns (int200) {
+        return int200(uint200(kevm.freshUInt(25, var_name)));
+    }
+
+    function freshSInt192(string memory var_name) internal returns (int192) {
+        return int192(uint192(kevm.freshUInt(24, var_name)));
+    }
+
+    function freshSInt184(string memory var_name) internal returns (int184) {
+        return int184(uint184(kevm.freshUInt(23, var_name)));
+    }
+
+    function freshSInt176(string memory var_name) internal returns (int176) {
+        return int176(uint176(kevm.freshUInt(22, var_name)));
+    }
+
+    function freshSInt168(string memory var_name) internal returns (int168) {
+        return int168(uint168(kevm.freshUInt(21, var_name)));
+    }
+
+    function freshSInt160(string memory var_name) internal returns (int160) {
+        return int160(uint160(kevm.freshUInt(20, var_name)));
+    }
+
+    function freshSInt152(string memory var_name) internal returns (int152) {
+        return int152(uint152(kevm.freshUInt(19, var_name)));
+    }
+
+    function freshSInt144(string memory var_name) internal returns (int144) {
+        return int144(uint144(kevm.freshUInt(18, var_name)));
+    }
+
+    function freshSInt136(string memory var_name) internal returns (int136) {
+        return int136(uint136(kevm.freshUInt(17, var_name)));
+    }
+
+    function freshSInt128(string memory var_name) internal returns (int128) {
+        return int128(uint128(kevm.freshUInt(16, var_name)));
+    }
+
+    function freshSInt120(string memory var_name) internal returns (int120) {
+        return int120(uint120(kevm.freshUInt(15, var_name)));
+    }
+
+    function freshSInt112(string memory var_name) internal returns (int112) {
+        return int112(uint112(kevm.freshUInt(14, var_name)));
+    }
+
+    function freshSInt104(string memory var_name) internal returns (int104) {
+        return int104(uint104(kevm.freshUInt(13, var_name)));
+    }
+
+    function freshSInt96(string memory var_name) internal returns (int96) {
+        return int96(uint96(kevm.freshUInt(12, var_name)));
+    }
+
+    function freshSInt88(string memory var_name) internal returns (int88) {
+        return int88(uint88(kevm.freshUInt(11, var_name)));
+    }
+
+    function freshSInt80(string memory var_name) internal returns (int80) {
+        return int80(uint80(kevm.freshUInt(10, var_name)));
+    }
+
+    function freshSInt72(string memory var_name) internal returns (int72) {
+        return int72(uint72(kevm.freshUInt(9, var_name)));
+    }
+
+    function freshSInt64(string memory var_name) internal returns (int64) {
+        return int64(uint64(kevm.freshUInt(8, var_name)));
+    }
+
+    function freshSInt56(string memory var_name) internal returns (int56) {
+        return int56(uint56(kevm.freshUInt(7, var_name)));
+    }
+
+    function freshSInt48(string memory var_name) internal returns (int48) {
+        return int48(uint48(kevm.freshUInt(6, var_name)));
+    }
+
+    function freshSInt40(string memory var_name) internal returns (int40) {
+        return int40(uint40(kevm.freshUInt(5, var_name)));
+    }
+
+    function freshSInt32(string memory var_name) internal returns (int32) {
+        return int32(uint32(kevm.freshUInt(4, var_name)));
+    }
+
+    function freshSInt24(string memory var_name) internal returns (int24) {
+        return int24(uint24(kevm.freshUInt(3, var_name)));
+    }
+
+    function freshSInt16(string memory var_name) internal returns (int16) {
+        return int16(uint16(kevm.freshUInt(2, var_name)));
+    }
+
+    function freshSInt8(string memory var_name) internal returns (int8) {
+        return int8(uint8((kevm.freshUInt(1, var_name))));
+    }
 }


### PR DESCRIPTION
Updated version of: https://github.com/runtimeverification/kontrol-cheatcodes/pull/6.

Adding cheat codes that generate symbolic variables with a custom name.