### PR TITLE
Add `allowCalls` cheatcode

### DIFF
--- a/src/IKontrolCheatsBase.sol
+++ b/src/IKontrolCheatsBase.sol
@@ -24,6 +24,8 @@ interface KontrolCheatsBase {
     function symbolicStorage(address, string calldata) external;
     // Adds an address to the whitelist.
     function allowCallsToAddress(address) external;
+    // Adds an address and calldata to the whitelist.
+    function allowCalls(address, bytes memory) external;
     // Adds an address and a storage slot to the whitelist.
     function allowChangesToStorage(address,uint256) external;
     // Sets the remaining gas to an infinite value.

--- a/src/IKontrolCheatsBase.sol
+++ b/src/IKontrolCheatsBase.sol
@@ -25,7 +25,7 @@ interface KontrolCheatsBase {
     // Adds an address to the whitelist.
     function allowCallsToAddress(address) external;
     // Adds an address and calldata to the whitelist.
-    function allowCalls(address, bytes memory) external;
+    function allowCalls(address, bytes calldata) external;
     // Adds an address and a storage slot to the whitelist.
     function allowChangesToStorage(address,uint256) external;
     // Sets the remaining gas to an infinite value.


### PR DESCRIPTION
Related: https://github.com/runtimeverification/kontrol/pull/926.

This PR adds the `allowCalls` cheatcode that enables whitelisting `address` and specific `calldata`:
```solidity
    // Adds an address and calldata to the whitelist.
    function allowCalls(address, bytes calldata) external;
```
constituting a more specific version of 
```solidity
    // Adds an address to the whitelist.
    function allowCallsToAddress(address) external;
```

It can then be used as follows:
```solidity
  function testExecuteOnlyCallsSubmittedProposals(uint256 proposalId) external {
      Timelock timelock = new Timelock();
      
      // Whitelist one call to the timelock
      bytes memory timelockCalldata = abi.encodeWithSelector(
	      Timelock.execute.selector,
	      proposalId
      );
      kevm.allowCalls(address(timelock), timelockCalldata);

      // Whitelist another call to the timelock
      bytes memory timelockCalldataAnother = abi.encodeWithSelector(
	      Timelock.anotherCall.selector,
	      proposalId
      );
      kevm.allowCalls(address(timelock), timelockCalldataAnother);
      
      // Perform a whitelisted call
      timelock.execute(proposalId);

      // Perform another non-whitelisted call that will cause failure
      timelock.set(proposalId);
  }
```